### PR TITLE
No formal dependency on roxygen2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
   MASS
 Suggests:
     knitr,
-    rmarkdown,
-    roxygen2
+    rmarkdown
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
+Config/Needs/development: roxygen2


### PR DESCRIPTION
I don't see any actual _code_ using {roxygen2} -- it's only needed for package development.

I moved it to `Config/needs/development` to convey "I use {roxygen2} but you don't need to".

I also use this DESCRIPTION key elsewhere, e.g.

https://github.com/r-lib/lintr/blob/16ae3dc436f10e373afee677c97a96002c587c2d/DESCRIPTION#L57

I find it helpful for specifying GitHub Codespaces, for example.

By leaving it in `Suggests`, it makes it slightly more difficult to develop in containers because that's another few packages to install (especially, heavy ones like {rlang}/{vctrs}, and an implicit `SystemRequirement` on `libxml2-dev`).