### PR TITLE
Explicit cast of difftime to numeric

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -72,7 +72,7 @@ hours_decimal <- function(time) {
 
 # Compute durations between events (hours)
 duration_hours <- function(days1, time1, days2, time2) {
-  (days2 - days1)*24 + (hours_decimal(time2) - hours_decimal(time1))
+  (as.double(days2 - days1))*24 + (hours_decimal(time2) - hours_decimal(time1))
 }
 
 # Function for converting a set of numbers to a factor, ordering levels by group size


### PR DESCRIPTION
This relies on IMO a bug in IDate where t1 - t2 is a simple integer, whereas Date-Date is always class difftime:

```r
library(data.table)
t1 = Sys.Date()
t2 = t1 + 1

str(t1 - t2)
#  'difftime' num -1
#  - attr(*, "units")= chr "days"

str(as.IDate(t1) - as.IDate(t2))
## current CRAN 1.17.6
#  int -1

## current dev after change
#  'difftime' int -1
#  - attr(*, "units")= chr "days"
```

`as.integer()` could work but it's cast to double by the remaining operations anyway.

I plan to add a back-compatibility option to `-.IDate` for this release, but it will eventually change.